### PR TITLE
#23- Added: Show the event registration is active or inactive, Fixed: Redirecting to wrong route after creating an event

### DIFF
--- a/src/app/(event)/add-event/page.tsx
+++ b/src/app/(event)/add-event/page.tsx
@@ -146,7 +146,7 @@ export default function AddEvent() {
 
       setImageUrls([]);
       toast.success("Event created successfully!");
-      router.push(`/events/${data[0].id}`);
+      router.push(`/explore-events/${data[0].id}`);
     });
   };
 
@@ -263,6 +263,7 @@ export default function AddEvent() {
             <label htmlFor="event_duration">Event Duration(In hours): </label>
             <input
               type="number"
+              min={0}
               placeholder="Enter Event Duration (In hours)"
               {...register("event_duration", { required: true })}
               className="w-full p-2 text-white bg-black border border-white rounded-md"
@@ -273,6 +274,7 @@ export default function AddEvent() {
             <label htmlFor="team_size">Event Team Size: </label>
             <input
               type="number"
+              min={0}
               placeholder="Enter Team Size"
               {...register("team_size", { required: true })}
               className="w-full p-2 text-white bg-black border border-white rounded-md"
@@ -293,6 +295,7 @@ export default function AddEvent() {
             <label htmlFor="event_price">Event Price: </label>
             <input
               type="number"
+              min={0}
               placeholder="Enter Event Price (INR)"
               {...register("event_price", { required: true })}
               className="w-full p-2 text-white bg-black border border-white rounded-md"

--- a/src/app/(event)/explore-events/page.tsx
+++ b/src/app/(event)/explore-events/page.tsx
@@ -176,67 +176,77 @@ const Page: React.FC = () => {
         ) : (
           <div className="w-full flex flex-wrap gap-5 justify-evenly py-[4rem]">
             {currentItems.length > 0 ? (
-              currentItems.map((event: any) => (
-                <div
-                  className="cursor-pointer w-[350px] mx-auto bg-black text-white rounded-xl shadow-md overflow-hidden transition duration-300 ease-in-out transform hover:scale-105"
-                  key={event.id}
-                >
-                  <div className="relative h-64">
-                    <Image
-                      width="500"
-                      height="500"
-                      src={JSON.parse(event.event_images[0]?.url)[0]}
-                      alt={event.event_title}
-                      className="w-full h-full object-cover"
-                    />
-                    <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black to-transparent p-4">
-                      <h2 className="text-lg font-bold leading-tight text-white">
-                        {event.event_title}
-                      </h2>
+              currentItems.map((event: any) => {
+                const isActive = new Date(event.event_startdate) >= new Date();
+                return (
+                  <div
+                    className="cursor-pointer w-[350px] mx-auto bg-black text-white rounded-xl shadow-md overflow-hidden transition duration-300 ease-in-out transform hover:scale-105"
+                    key={event.id}
+                  >
+                    <div className="relative h-64">
+                      <Image
+                        width="500"
+                        height="500"
+                        src={JSON.parse(event.event_images[0]?.url)[0]}
+                        alt={event.event_title}
+                        className="w-full h-full object-cover"
+                      />
+                      <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black to-transparent p-4">
+                        <h2 className="text-lg font-bold leading-tight text-white">
+                          {event.event_title}
+                        </h2>
+                      </div>
                     </div>
-                  </div>
-                  <div className="p-4 text-white">
-                    <div className="flex justify-between items-start mb-2">
-                      <span className="px-2 py-1 text-xs font-semibold rounded-full bg-purple-100 text-purple-800">
-                        {event.event_category}
-                      </span>
-                      <span className="text-sm font-semibold">
-                        ${event.event_price}
-                      </span>
-                    </div>
-                    <p className="text-xs mb-3 line-clamp-2">
-                      {event.event_description}
-                    </p>
-                    <div className="space-y-2">
-                      <div className="flex items-center space-x-2 text-xs">
-                        <CalendarIcon className="h-3 w-3" />
-                        <span>
-                          {" "}
-                          {new Date(event.event_startdate).toLocaleString(
-                            undefined,
-                            {
-                              year: "numeric",
-                              month: "short",
-                              day: "numeric",
-                            }
-                          )}
+                    <div className="p-4 text-white">
+                      <div className="flex justify-between items-start mb-2">
+                        <span className="flex gap-3">
+                          <span className="px-2 py-1 text-xs font-semibold rounded-full bg-purple-100 text-purple-800">
+                            {event.event_category}
+                          </span>
+                          <span
+                            className={`px-2 py-1 text-xs font-semibold rounded-full ${isActive ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"}`}
+                          >
+                            {isActive ? "Active" : "Inactive"}
+                          </span>
+                        </span>
+                        <span className="text-sm font-semibold">
+                          ${event.event_price}
                         </span>
                       </div>
-                      <div className="flex items-center space-x-2 text-xs">
-                        <MapPinIcon className="h-3 w-3" />
-                        <span className="truncate">{event.event_location}</span>
+                      <p className="text-xs mb-3 line-clamp-2">
+                        {event.event_description}
+                      </p>
+                      <div className="space-y-2">
+                        <div className="flex items-center space-x-2 text-xs">
+                          <CalendarIcon className="h-3 w-3" />
+                          <span>
+                            {" "}
+                            {new Date(event.event_startdate).toLocaleString(
+                              undefined,
+                              {
+                                year: "numeric",
+                                month: "short",
+                                day: "numeric",
+                              }
+                            )}
+                          </span>
+                        </div>
+                        <div className="flex items-center space-x-2 text-xs">
+                          <MapPinIcon className="h-3 w-3" />
+                          <span className="truncate">{event.event_location}</span>
+                        </div>
                       </div>
                     </div>
+                    <div className="px-4 pb-4">
+                      <Link href={`/explore-events/${event.id}`}>
+                        <button className="w-full bg-black border text-white text-sm font-semibold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
+                          View Details
+                        </button>
+                      </Link>
+                    </div>
                   </div>
-                  <div className="px-4 pb-4">
-                    <Link href={`/explore-events/${event.id}`}>
-                      <button className="w-full bg-black border text-white text-sm font-semibold py-2 px-4 rounded-lg transition duration-300 ease-in-out">
-                        View Details
-                      </button>
-                    </Link>
-                  </div>
-                </div>
-              ))
+                )
+              })
             ) : (
               <div className="h-screen flex flex-col justify-center items-center text-3xl font-bold">
                 Event Not Found

--- a/src/components/EventPageClient.tsx
+++ b/src/components/EventPageClient.tsx
@@ -97,7 +97,9 @@ const EventPageClient = ({ eventsId }: { eventsId: string }) => {
   return (
     <>
       <div className="w-full h-auto bg-black text-white py-[5rem] md:py-[8rem] px-[1rem] md:px-[2rem]">
-        {eventData.map((event: any) => (
+        {eventData.map((event: any) => {
+          const isActive = new Date(event.event_startdate) >= new Date();
+          return (
           <div
             className="flex flex-wrap justify-center items-center"
             key={event.id}
@@ -155,10 +157,13 @@ const EventPageClient = ({ eventsId }: { eventsId: string }) => {
                 <h1 className="flex flex-row items-center gap-4">
                   Location : {event.event_location}
                 </h1>
-                <h1 className="flex flex-row items-center">
+                <h1 className="flex flex-row items-center gap-3">
                   <Badge variant="destructive">
                     <span>&#8377;</span>
                     {event.event_price}
+                  </Badge>
+                  <Badge variant="destructive" className={`${isActive ? "bg-green-100 text-green-800" : "bg-red-100 text-red-800"}`}>
+                  { isActive ? "Active" : "Inactive" }
                   </Badge>
                 </h1>
 
@@ -272,7 +277,7 @@ const EventPageClient = ({ eventsId }: { eventsId: string }) => {
               </div>
             </div>
           </div>
-        ))}
+        )})}
       </div>
     </>
   );


### PR DESCRIPTION
Added Active/Inactive indicator in `explore-events` and `explore-events/[eventtsId]`
![Screenshot 2024-10-10 023305](https://github.com/user-attachments/assets/e50ee6ca-65eb-467e-9cbf-975159faa163)
![Screenshot 2024-10-10 022618](https://github.com/user-attachments/assets/ad6b6502-6cce-4549-8ab8-c738c335b13d)

After creating an event page was redirecting to `events/eventid` where it should've redirect to `explore-events/eventId`
![Screenshot 2024-10-09 025217](https://github.com/user-attachments/assets/1128c6ca-28ac-40f5-8f92-d3e992dce9f2)