### PR TITLE
Navbar fix for smaller screens

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -140,7 +140,7 @@ function Header() {
             <div className="flex flex-col gap-8 text-white text-center items-center">
               {renderMenuItems()}
             </div>
-            <button onClick={toggleTheme} className={isMenuOpen ? "rounded-md absolute top-5 right-12 lg:hidden" : ""}>
+            <button onClick={toggleTheme} className={isMenuOpen ? "rounded-md absolute top-5 left-4 lg:hidden" : ""}>
               {isDarkMode ? (
                 <BsBrightnessLow size={22} />
               ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -211,7 +211,7 @@ function Header() {
                 </div>
                 {isDropdownVisible && (
                   <div
-                    className="absolute right-0 p-2 mt-0 w-auto bg-black text-white dark:bg-white dark:text-black rounded-md shadow-lg z-20"
+                    className="absolute lg:right-0 p-2 mt-0 w-auto bg-black text-white dark:bg-white dark:text-black rounded-md shadow-lg z-20 lg:top-13 lg:bottom-auto bottom-12 -right-20"
                     onMouseEnter={showDropdown}
                     onMouseLeave={hideDropdown}
                   >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -140,6 +140,13 @@ function Header() {
             <div className="flex flex-col gap-8 text-white text-center items-center">
               {renderMenuItems()}
             </div>
+            <button onClick={toggleTheme} className={isMenuOpen ? "rounded-md absolute top-5 right-12 lg:hidden" : ""}>
+              {isDarkMode ? (
+                <BsBrightnessLow size={22} />
+              ) : (
+                <IoMoon size={22} />
+              )}
+            </button>
           </div>
         </div>
       )}
@@ -235,7 +242,7 @@ function Header() {
                 )}
               </div>
             </div>
-            <button onClick={toggleTheme} className="p-2 rounded-md">
+            <button onClick={toggleTheme} className="p-2 rounded-md hidden lg:block">
               {isDarkMode ? (
                 <BsBrightnessLow size={24} />
               ) : (
@@ -258,7 +265,7 @@ function Header() {
               Sign up
             </RegisterLink>
 
-            <button onClick={toggleTheme} className="bg-black p-2 rounded-md">
+            <button onClick={toggleTheme} className="bg-black p-2 rounded-md hidden lg:block">
               {isDarkMode ? (
                 <BsBrightnessLow size={24} />
               ) : (


### PR DESCRIPTION
This PR addresses #217 

The changes I made are as follows, `(All the changes were made in the src/components/Header.tsx file)`:
- Modified classes for the dropdown menu for the account page so that the position is dynamic based on the screen size
- Added classes for the div holding the theme icon so that it shows up on the top left in smaller screens.

The final form is as belows:
- For smaller screen 
<img width="366" alt="image" src="https://github.com/user-attachments/assets/fb028ed0-9aa2-4606-b62a-fb3ea8f4a928">
- For full screen (normal behaviour)
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/c76ab2c1-189e-4bc6-89f9-9414d08db7d3">


Let me know if there are any questions or further adjustments needed.